### PR TITLE
Grails 2.x deprecated & MongoDB changes

### DIFF
--- a/grails-app/domain/grails/plugin/nimble/core/Group.groovy
+++ b/grails-app/domain/grails/plugin/nimble/core/Group.groovy
@@ -16,8 +16,7 @@
  */
 package grails.plugin.nimble.core
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
-
+import grails.util.Holders as ConfigurationHolder // Since Grails 2.x ConfigurationHolder is deprecated 
 /**
  * Represents a grouping of users in a Nimble based appication
  *

--- a/grails-app/domain/grails/plugin/nimble/core/LevelPermission.groovy
+++ b/grails-app/domain/grails/plugin/nimble/core/LevelPermission.groovy
@@ -16,7 +16,7 @@
  */
 package grails.plugin.nimble.core
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
+import grails.util.Holders as ConfigurationHolder // Since Grails 2.x ConfigurationHolder is deprecated 
 
 /**
  * Represents a WildcardPermission in the data repository.
@@ -31,12 +31,12 @@ class LevelPermission extends Permission {
 	private static final String levelSep = ":"
 
 	static hasMany = [
-		first: String,
-		second: String,
-		third: String,
-		fourth: String,
-		fifth: String,
-		sixth: String
+		tokenFirst: String,
+		tokenSecond: String,
+		tokenThird: String,
+		tokenFourth: String,
+		tokenFifth: String,
+		tokenSixth: String
 	]
 
 	static mapping = {
@@ -45,12 +45,12 @@ class LevelPermission extends Permission {
 	}
 
 	static constraints = {
-		first(minSize: 1)
-		second(nullable: true)
-		third(nullable: true)
-		fourth(nullable: true)
-		fifth(nullable: true)
-		sixth(nullable: true)
+		tokenFirst(minSize: 1)
+		tokenSecond(nullable: true)
+		tokenThird(nullable: true)
+		tokenFourth(nullable: true)
+		tokenFifth(nullable: true)
+		tokenSixth(nullable: true)
 	}
 
 	LevelPermission() {
@@ -60,18 +60,18 @@ class LevelPermission extends Permission {
 	void buildTarget() {
 		StringBuilder target = new StringBuilder()
 
-		if (first) {
-			addTokens first, target, false
-			if (second) {
-				addTokens second, target
-				if (third) {
-					addTokens third, target
-					if (fourth) {
-						addTokens fourth, target
-						if (fifth) {
-							addTokens fifth, target
-							if (sixth) {
-								addTokens sixth, target
+		if (tokenFirst) {
+			addTokens tokenFirst, target, false
+			if (tokenSecond) {
+				addTokens tokenSecond, target
+				if (tokenThird) {
+					addTokens tokenThird, target
+					if (tokenFourth) {
+						addTokens tokenFourth, target
+						if (tokenFifth) {
+							addTokens tokenFifth, target
+							if (tokenSixth) {
+								addTokens tokenSixth, target
 							}
 						}
 					}
@@ -116,42 +116,42 @@ class LevelPermission extends Permission {
 			return
 		}
 
-		this.first = splitByTokenSep(first)
+		this.tokenFirst = splitByTokenSep(first)
 
 		if (second) {
 			if (containsLevelSep(second, 'second')) {
 				return
 			}
 
-			this.second = splitByTokenSep(second)
+			this.tokenSecond = splitByTokenSep(second)
 
 			if (third) {
 				if (containsLevelSep(third, 'third')) {
 					return
 				}
 
-				this.third = splitByTokenSep(third)
+				this.tokenThird = splitByTokenSep(third)
 
 				if (fourth) {
 					if (containsLevelSep(fourth, 'fourth')) {
 						return
 					}
 
-					this.fourth = splitByTokenSep(fourth)
+					this.tokenFourth = splitByTokenSep(fourth)
 
 					if (fifth) {
 						if (containsLevelSep(fifth, 'fifth')) {
 							return
 						}
 
-						this.fifth = splitByTokenSep(fifth)
+						this.tokenFifth = splitByTokenSep(fifth)
 
 						if (sixth) {
 							if (containsLevelSep(sixth, 'sixth')) {
 								return
 							}
 
-							this.sixth = splitByTokenSep(sixth)
+							this.tokenSixth = splitByTokenSep(sixth)
 						}
 					}
 				}

--- a/grails-app/domain/grails/plugin/nimble/core/LoginRecord.groovy
+++ b/grails-app/domain/grails/plugin/nimble/core/LoginRecord.groovy
@@ -16,7 +16,7 @@
  */
 package grails.plugin.nimble.core
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
+import grails.util.Holders as ConfigurationHolder // Since Grails 2.x ConfigurationHolder is deprecated 
 /**
  * Represents a system that a user logged into a Nimble based application from
  *

--- a/grails-app/domain/grails/plugin/nimble/core/Permission.groovy
+++ b/grails-app/domain/grails/plugin/nimble/core/Permission.groovy
@@ -16,7 +16,7 @@
  */
 package grails.plugin.nimble.core
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
+import grails.util.Holders as ConfigurationHolder // Since Grails 2.x ConfigurationHolder is deprecated 
 
 /**
  * Our permission object encapsulates details that a normal Shiro deployment

--- a/grails-app/domain/grails/plugin/nimble/core/ProfileBase.groovy
+++ b/grails-app/domain/grails/plugin/nimble/core/ProfileBase.groovy
@@ -17,7 +17,7 @@
 package grails.plugin.nimble.core
 
 import org.apache.shiro.crypto.hash.Md5Hash
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
+import grails.util.Holders as ConfigurationHolder // Since Grails 2.x ConfigurationHolder is deprecated 
 
 /**
  * Represents generic details about users that are useful to many applications

--- a/grails-app/domain/grails/plugin/nimble/core/Role.groovy
+++ b/grails-app/domain/grails/plugin/nimble/core/Role.groovy
@@ -16,7 +16,7 @@
  */
 package grails.plugin.nimble.core
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
+import grails.util.Holders as ConfigurationHolder // Since Grails 2.x ConfigurationHolder is deprecated 
 
 /**
  * Represents a role within a Nimble application

--- a/grails-app/domain/grails/plugin/nimble/core/Url.groovy
+++ b/grails-app/domain/grails/plugin/nimble/core/Url.groovy
@@ -16,7 +16,7 @@
  */
 package grails.plugin.nimble.core
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
+import grails.util.Holders as ConfigurationHolder // Since Grails 2.x ConfigurationHolder is deprecated 
 
 /**
  * Represents a web based url with extended information for display purposes.

--- a/grails-app/domain/grails/plugin/nimble/core/UserBase.groovy
+++ b/grails-app/domain/grails/plugin/nimble/core/UserBase.groovy
@@ -16,7 +16,7 @@
  */
 package grails.plugin.nimble.core
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
+import grails.util.Holders as ConfigurationHolder // Since Grails 2.x ConfigurationHolder is deprecated 
 
 /**
  * Represents a user within a Nimble Application

--- a/test/unit/grails/plugin/nimble/core/LevelPermissionTests.groovy
+++ b/test/unit/grails/plugin/nimble/core/LevelPermissionTests.groovy
@@ -33,7 +33,7 @@ class LevelPermissionTests extends GroovyTestCase {
 	private owner = new Expando(name: "Test owner")
 
 	private LevelPermission createValidLevelPermission() {
-		def p = new LevelPermission(first:first, second:second, third:third, fourth:fourth, fifth:fifth, sixth:sixth)
+		def p = new LevelPermission(tokenFirst:first, tokenSecond:second, tokenThird:third, tokenFourth:fourth, tokenFifth:fifth, tokenSixth:sixth)
 		p.owner = owner
 		p.buildTarget()
 		p
@@ -42,20 +42,20 @@ class LevelPermissionTests extends GroovyTestCase {
 	void testLevelPermissionCreation() {
 		def levelPermission = createValidLevelPermission()
 
-		assertTrue levelPermission.first.containsAll(first)
-		assertTrue levelPermission.second.containsAll(second)
-		assertTrue levelPermission.third.containsAll(third)
-		assertTrue levelPermission.fourth.containsAll(fourth)
-		assertTrue levelPermission.fifth.containsAll(fifth)
-		assertTrue levelPermission.sixth.containsAll(sixth)
+		assertTrue levelPermission.tokenFirst.containsAll(first)
+		assertTrue levelPermission.tokenSecond.containsAll(second)
+		assertTrue levelPermission.tokenThird.containsAll(third)
+		assertTrue levelPermission.tokenFourth.containsAll(fourth)
+		assertTrue levelPermission.tokenFifth.containsAll(fifth)
+		assertTrue levelPermission.tokenSixth.containsAll(sixth)
 
 		// Do some random checks to ensure there isn't any contamination
-		assertFalse levelPermission.first.contains(sixth)
-		assertFalse levelPermission.second.contains(fifth)
-		assertFalse levelPermission.third.contains(fourth)
-		assertFalse levelPermission.fourth.contains(third)
-		assertFalse levelPermission.fifth.contains(second)
-		assertFalse levelPermission.sixth.contains(first)
+		assertFalse levelPermission.tokenFirst.contains(sixth)
+		assertFalse levelPermission.tokenSecond.contains(fifth)
+		assertFalse levelPermission.tokenThird.contains(fourth)
+		assertFalse levelPermission.tokenFourth.contains(third)
+		assertFalse levelPermission.tokenFifth.contains(second)
+		assertFalse levelPermission.tokenSixth.contains(first)
 
 		assertEquals levelPermission.type, Permission.defaultPerm
 	}
@@ -65,15 +65,15 @@ class LevelPermissionTests extends GroovyTestCase {
 
 		assertTrue levelPermission.validate()
 
-		levelPermission.first = ['localtarget']
+		levelPermission.tokenFirst = ['localtarget']
 		levelPermission.buildTarget()
 		assertTrue levelPermission.validate()
 
-		levelPermission.first = []
+		levelPermission.tokenFirst = []
 		levelPermission.buildTarget()
 		assertFalse levelPermission.validate()
 
-		levelPermission.first = null
+		levelPermission.tokenFirst = null
 		levelPermission.buildTarget()
 		assertFalse levelPermission.validate()
 	}
@@ -83,7 +83,7 @@ class LevelPermissionTests extends GroovyTestCase {
 
 		assertTrue levelPermission.validate()
 
-		levelPermission.second = null
+		levelPermission.tokenSecond = null
 		levelPermission.buildTarget()
 		assertTrue levelPermission.validate()
 	}
@@ -93,7 +93,7 @@ class LevelPermissionTests extends GroovyTestCase {
 
 		assertTrue levelPermission.validate()
 
-		levelPermission.third = null
+		levelPermission.tokenThird = null
 		levelPermission.buildTarget()
 		assertTrue levelPermission.validate()
 	}
@@ -103,7 +103,7 @@ class LevelPermissionTests extends GroovyTestCase {
 
 		assertTrue levelPermission.validate()
 
-		levelPermission.fourth = null
+		levelPermission.tokenFourth = null
 		levelPermission.buildTarget()
 		assertTrue levelPermission.validate()
 	}
@@ -113,7 +113,7 @@ class LevelPermissionTests extends GroovyTestCase {
 
 		assertTrue levelPermission.validate()
 
-		levelPermission.fifth = null
+		levelPermission.tokenFifth = null
 		levelPermission.buildTarget()
 		assertTrue levelPermission.validate()
 	}
@@ -123,7 +123,7 @@ class LevelPermissionTests extends GroovyTestCase {
 
 		assertTrue levelPermission.validate()
 
-		levelPermission.sixth = null
+		levelPermission.tokenSixth = null
 		levelPermission.buildTarget()
 		assertTrue levelPermission.validate()
 	}
@@ -139,7 +139,7 @@ class LevelPermissionTests extends GroovyTestCase {
 		def levelPermission = createValidLevelPermission()
 		String expected = 'token01,token02'
 
-		levelPermission.second = null
+		levelPermission.tokenSecond = null
 		levelPermission.buildTarget()
 
 		assertEquals levelPermission.target, expected
@@ -149,7 +149,7 @@ class LevelPermissionTests extends GroovyTestCase {
 		def levelPermission = createValidLevelPermission()
 		String expected = 'token01,token02:token03,token04'
 
-		levelPermission.third = null
+		levelPermission.tokenThird = null
 		levelPermission.buildTarget()
 
 		assertEquals levelPermission.target, expected
@@ -159,7 +159,7 @@ class LevelPermissionTests extends GroovyTestCase {
 		def levelPermission = createValidLevelPermission()
 		String expected = 'token01,token02:token03,token04:token05,token06'
 
-		levelPermission.fourth = null
+		levelPermission.tokenFourth = null
 		levelPermission.buildTarget()
 
 		assertEquals levelPermission.target, expected
@@ -169,7 +169,7 @@ class LevelPermissionTests extends GroovyTestCase {
 		def levelPermission = createValidLevelPermission()
 		String expected = 'token01,token02:token03,token04:token05,token06:token07,token08'
 
-		levelPermission.fifth = null
+		levelPermission.tokenFifth = null
 		levelPermission.buildTarget()
 
 		assertEquals levelPermission.target, expected
@@ -179,7 +179,7 @@ class LevelPermissionTests extends GroovyTestCase {
 		def levelPermission = createValidLevelPermission()
 		String expected = 'token01,token02:token03,token04:token05,token06:token07,token08:token09,token10'
 
-		levelPermission.sixth = null
+		levelPermission.tokenSixth = null
 		levelPermission.buildTarget()
 
 		assertEquals levelPermission.target, expected
@@ -189,9 +189,9 @@ class LevelPermissionTests extends GroovyTestCase {
 		def levelPermission = new LevelPermission()
 		String expected = 'token01:token02,token03,token04:token05,token06'
 
-		levelPermission.first = ['token01']
-		levelPermission.second = ['token02','token03','token04']
-		levelPermission.third = ['token05','token06']
+		levelPermission.tokenFirst = ['token01']
+		levelPermission.tokenSecond = ['token02','token03','token04']
+		levelPermission.tokenThird = ['token05','token06']
 		levelPermission.buildTarget()
 
 		assertEquals levelPermission.target, expected


### PR DESCRIPTION
1. ConfigurationHolder  is no more supported in Grails 2.x  and hence
   using 'import grails.util.Holders as ConfigurationHolder '
2. 'first' in LevelPermission causes issues with MongoDB. changing the
   member names
