### PR TITLE
Use username minimum length from config in model

### DIFF
--- a/grails-app/domain/grails/plugin/nimble/core/UserBase.groovy
+++ b/grails-app/domain/grails/plugin/nimble/core/UserBase.groovy
@@ -53,8 +53,9 @@ class UserBase implements Serializable {
 	}
 
 	static constraints = {
-		username(blank: false, unique: true, minSize: 4, maxSize: 255)
-		passwordHash(nullable: true, blank: false)
+		username(blank: false, unique: true, maxSize: 255, 
+			minSize: ConfigurationHolder.config.nimble.localusers.usernames.minlength)
+		passwordHash(nullable: true, blank: false
 		actionHash(nullable: true, blank: false)
 		realm(nullable: true, blank: false)
 		expiration(nullable: true)


### PR DESCRIPTION
There is a configuration parameter for setting the minimum username length, but the model has a hardcoded minimum of 4. This is an issue if you need usernames shorter than 4.
